### PR TITLE
Add support for layer IDs

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Vpype plugin to generate gcode and other text output.
 See: https://github.com/abey79/vpype
 
 
-Gcode vpype plugin. Write gcode files for the vpype pipeline. The output format can be customized by the user heavily to an extend that you can also output non gcode ascii text files. 
+Gcode vpype plugin. Write gcode files for the vpype pipeline. The output format can be customized by the user heavily to an extent that you can also output non gcode ascii text files. 
 
 * `gwrite` write geometries as gcode to a file
 
@@ -81,13 +81,13 @@ These parameters define the transformation between *vpype*'s and the target's co
 - `offset_y`: Apply an offset to the Y axis. This offset is expressed in the unit defined by `unit`.
 
 ### Output Format
-All of the options below default to an empty text which means no output is generated. However, if `segment_first` or `segment_last` is omitted the code from `segment` is used. If there is only one segment. `segment_first` takes priority over `segment_last`.
-- `document_start`: Output to be generated at the start of the file as a document_start
-- `document_end`: Output to be generated at the end of the file as a document_end
-- `layer_start`: Output to be generated before a layer is started
+All of the options below default to an empty text which means no output is generated. However, if `segment_first` or `segment_last` is omitted the code from `segment` is used. If there is only one segment, `segment_first` takes priority over `segment_last`.
+- `document_start`: Output to be generated at the start of the file as a document_start.
+- `document_end`: Output to be generated at the end of the file as a document_end.
+- `layer_start`: Output to be generated before a layer is started.
 - `layer_end`: Output to be generated after a layer is finished.
 - `layer_join`: Output to be generated between two layers.
-- `line_start`: Output to be generated before a line is started
+- `line_start`: Output to be generated before a line is started.
 - `line_end`: Output to be generated after a line is finished.
 - `line_join`: Output to be generated between two lines.
 - `segment_first`: Output to be generated at the first coordinate pair.
@@ -97,8 +97,8 @@ All of the options below default to an empty text which means no output is gener
 ### Segment formatting
 `gwrite` uses `.format()` encoding which means that data elements must be encapsulated in `{}` brackets. This provides a particular syntax token which differs from between elements.
 For example every element except `layer_join` and `segment_join` accepts the value of `index`. You would encode that in the text as `{index:d}` the d denotes an integer value. If you need to have a `{` value in your text you would encode that as `{{` likewise you would encode a `}` as `}}`.
-- `layer_start`: Accepts `index` the current layer number.
-- `layer_end`: Accepts `index` the current layer number.
+- `layer_start`: Accepts `index` the current layer number and `layer_id` as vpype layer ID.
+- `layer_end`: Accepts `index` the current layer number and `layer_id` as vpype layer ID.
 - `line_start`: Accepts `index` the current line number.
 - `line_end`: Accepts `index` the current line number.
   

--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,5 @@
 from setuptools import setup
 
-
 with open("README.md") as f:
     readme = f.read()
 
@@ -18,7 +17,7 @@ setup(
         "Programming Language :: Python :: 3.6",
         "Programming Language :: Python :: 3.7",
         "License :: OSI Approved :: MIT License",
-        "Operating System :: OS Independent"
+        "Operating System :: OS Independent",
     ),
     include_package_data=True,
     install_requires=[

--- a/vpype_gcode/gwrite.py
+++ b/vpype_gcode/gwrite.py
@@ -82,9 +82,10 @@ def gwrite(document: vp.Document, output: typing.TextIO, profile: str):
     xx = 0
     yy = 0
     lastlayer_index = len(document.layers.values()) - 1
-    for layer_index, layer in enumerate(document.layers.values()):
+    for layer_index, layer_id in enumerate(document.layers):
+        layer = document.layers[layer_id]
         if layer_start is not None:
-            output.write(layer_start.format(index=layer_index))
+            output.write(layer_start.format(index=layer_index, layer_id=layer_id))
         lastlines_index = len(layer) - 1
         for lines_index, line in enumerate(layer):
             if line_start is not None:
@@ -130,7 +131,7 @@ def gwrite(document: vp.Document, output: typing.TextIO, profile: str):
             if line_join is not None and lines_index != lastlines_index:
                 output.write(line_join)
         if layer_end is not None:
-            output.write(layer_end.format(index=layer_index))
+            output.write(layer_end.format(index=layer_index, layer_id=layer_id))
         if layer_join is not None and layer_index != lastlayer_index:
             output.write(layer_join)
     if document_end is not None:


### PR DESCRIPTION
In vpype, layer IDs as used to refer to layers and maybe arbitrary non-zero, positive integers. In particular, they do not need to be consecutive and the `read` command attempts to honour them according to a [well defined heuristic](https://vpype.readthedocs.io/en/stable/reference.html#read). Since they can be set to an arbitrary value by the user, they can potentially be useful in vpype-gcode's output. This PR adds the formatting keyword `layer_id` to the `layer_start` and `layer_end` elements.

Other minor fixes:
- some typos in the readme
- black formatting of setup.py